### PR TITLE
Parse call frame information using std.dwarf and rework output to match zig-dwarfump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+zig-cache/
+zig-out/

--- a/build.zig
+++ b/build.zig
@@ -13,9 +13,9 @@ pub fn build(b: *std.build.Builder) void {
     exe.addAnonymousModule("clap", .{
         .source_file = .{ .path = "clap/clap.zig" },
     });
-    exe.install();
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
     if (b.args) |args| {
         run_cmd.addArgs(args);

--- a/src/Context.zig
+++ b/src/Context.zig
@@ -80,3 +80,10 @@ pub fn getDebugAbbrevData(base: *const Context) ?[]const u8 {
         .macho => @fieldParentPtr(MachO, "base", base).getDebugAbbrevData(),
     };
 }
+
+pub fn getArch(base: *const Context) ?std.Target.Cpu.Arch {
+    return switch (base.tag) {
+        .elf => @fieldParentPtr(Elf, "base", base).getArch(),
+        .macho => @fieldParentPtr(MachO, "base", base).getArch(),
+    };
+}

--- a/src/Context/Elf.zig
+++ b/src/Context/Elf.zig
@@ -18,7 +18,7 @@ eh_frame: ?std.elf.Elf64_Shdr = null,
 
 pub fn isElfFile(data: []const u8) bool {
     // TODO: 32bit ELF files
-    const header = @ptrCast(*const std.elf.Elf64_Ehdr, @alignCast(@alignOf(std.elf.Elf64_Ehdr), data.ptr)).*;
+    const header = @as(*const std.elf.Elf64_Ehdr, @ptrCast(@alignCast(data.ptr))).*;
     return std.mem.eql(u8, "\x7fELF", header.e_ident[0..4]);
 }
 
@@ -38,12 +38,12 @@ pub fn parse(gpa: Allocator, data: []const u8) !*Elf {
         },
         .header = undefined,
     };
-    elf.header = @ptrCast(*const std.elf.Elf64_Ehdr, @alignCast(@alignOf(std.elf.Elf64_Ehdr), data.ptr)).*;
+    elf.header = @as(*const std.elf.Elf64_Ehdr, @ptrCast(@alignCast(data.ptr))).*;
 
     const shdrs = elf.getShdrs();
     for (shdrs) |shdr| switch (shdr.sh_type) {
         std.elf.SHT_PROGBITS => {
-            const sh_name = elf.getShString(@intCast(u32, shdr.sh_name));
+            const sh_name = elf.getShString(@as(u32, @intCast(shdr.sh_name)));
             if (std.mem.eql(u8, sh_name, ".debug_info")) {
                 elf.debug_info_sect = shdr;
             }
@@ -101,9 +101,9 @@ pub fn getShdrByName(elf: *const Elf, name: []const u8) ?std.elf.Elf64_Shdr {
 }
 
 fn getShdrs(elf: *const Elf) []const std.elf.Elf64_Shdr {
-    const shdrs = @ptrCast(
+    const shdrs = @as(
         [*]const std.elf.Elf64_Shdr,
-        @alignCast(@alignOf(std.elf.Elf64_Shdr), elf.base.data.ptr + elf.header.e_shoff),
+        @ptrCast(@alignCast(elf.base.data.ptr + elf.header.e_shoff)),
     )[0..elf.header.e_shnum];
     return shdrs;
 }
@@ -116,7 +116,7 @@ fn getShString(elf: *const Elf, off: u32) []const u8 {
     const shdr = elf.getShdrs()[elf.header.e_shstrndx];
     const shstrtab = elf.getShdrData(shdr);
     std.debug.assert(off < shstrtab.len);
-    return std.mem.sliceTo(@ptrCast([*:0]const u8, shstrtab.ptr + off), 0);
+    return std.mem.sliceTo(@as([*:0]const u8, @ptrCast(shstrtab.ptr + off)), 0);
 }
 
 pub fn getArch(elf: *const Elf) ?std.Target.Cpu.Arch {

--- a/src/Context/MachO.zig
+++ b/src/Context/MachO.zig
@@ -15,7 +15,7 @@ debug_abbrev_sect: ?std.macho.section_64 = null,
 debug_string_sect: ?std.macho.section_64 = null,
 
 pub fn isMachOFile(data: []const u8) bool {
-    const header = @ptrCast(*const std.macho.mach_header_64, @alignCast(@alignOf(std.macho.mach_header_64), data.ptr)).*;
+    const header = @as(*const std.macho.mach_header_64, @ptrCast(@alignCast(data.ptr))).*;
     return header.magic == std.macho.MH_MAGIC_64;
 }
 
@@ -36,7 +36,7 @@ pub fn parse(gpa: Allocator, data: []const u8) !*MachO {
         .header = undefined,
     };
 
-    macho.header = @ptrCast(*const std.macho.mach_header_64, @alignCast(@alignOf(std.macho.mach_header_64), data.ptr)).*;
+    macho.header = @as(*const std.macho.mach_header_64, @ptrCast(@alignCast(data.ptr))).*;
 
     var it = macho.getLoadCommandsIterator();
     while (it.next()) |lc| switch (lc.cmd()) {
@@ -92,7 +92,7 @@ pub fn getSectionByName(macho: *const MachO, segname: []const u8, sectname: []co
 }
 
 pub fn getSectionData(macho: *const MachO, sect: std.macho.section_64) []const u8 {
-    const size = @intCast(usize, sect.size);
+    const size = @as(usize, @intCast(sect.size));
     return macho.base.data[sect.offset..][0..size];
 }
 
@@ -105,7 +105,7 @@ pub fn isARM(macho: *const MachO) bool {
 }
 
 fn getLoadCommandsIterator(macho: *const MachO) std.macho.LoadCommandIterator {
-    const data = @alignCast(@alignOf(u64), macho.base.data[@sizeOf(std.macho.mach_header_64)..])[0..macho.header.sizeofcmds];
+    const data = @as([]align(8) const u8, @alignCast(macho.base.data[@sizeOf(std.macho.mach_header_64)..]))[0..macho.header.sizeofcmds];
     return .{
         .ncmds = macho.header.ncmds,
         .buffer = data,

--- a/src/Context/MachO.zig
+++ b/src/Context/MachO.zig
@@ -111,3 +111,8 @@ fn getLoadCommandsIterator(macho: *const MachO) std.macho.LoadCommandIterator {
         .buffer = data,
     };
 }
+
+pub fn getArch(macho: *const MachO) ?std.Target.Cpu.Arch {
+    _ = macho;
+    return null;
+}

--- a/src/Context/MachO.zig
+++ b/src/Context/MachO.zig
@@ -113,6 +113,9 @@ fn getLoadCommandsIterator(macho: *const MachO) std.macho.LoadCommandIterator {
 }
 
 pub fn getArch(macho: *const MachO) ?std.Target.Cpu.Arch {
-    _ = macho;
-    return null;
+    return switch (macho.header.cputype) {
+        std.macho.CPU_TYPE_ARM64 => .aarch64,
+        std.macho.CPU_TYPE_X86_64 => .x86_64,
+        else => null,
+    };
 }

--- a/src/DwarfDump.zig
+++ b/src/DwarfDump.zig
@@ -901,7 +901,7 @@ pub fn printEhFrames(self: DwarfDump, writer: anytype, llvm_compatibility: bool)
                             llvm_compatibility,
                             .{
                                 .data = section.data.?,
-                                .offset = s.sh_offset,
+                                .offset = s.sh_addr,
                                 .frame_type = section.frame_type,
                             },
                             false,
@@ -1404,40 +1404,40 @@ fn writeOperands(
     endian: std.builtin.Endian,
 ) !void {
     switch (instruction) {
-        .set_loc => |i| try writer.print(" 0x{x}", .{i.operands.address}),
+        .set_loc => |i| try writer.print(" 0x{x}", .{i.address}),
         inline .advance_loc,
         .advance_loc1,
         .advance_loc2,
         .advance_loc4,
-        => |i| try writer.print(" {}", .{i.operands.delta * cie.code_alignment_factor}),
+        => |i| try writer.print(" {}", .{i.delta * cie.code_alignment_factor}),
         inline .offset,
         .offset_extended,
         .offset_extended_sf,
         => |i| try writer.print(" {} {d}", .{
-            fmtRegister(i.operands.register, reg_ctx, arch),
-            @as(i64, @intCast(i.operands.offset)) * cie.data_alignment_factor,
+            fmtRegister(i.register, reg_ctx, arch),
+            @as(i64, @intCast(i.offset)) * cie.data_alignment_factor,
         }),
         inline .restore,
         .restore_extended,
         .undefined,
         .same_value,
-        => |i| try writer.print(" {}", .{fmtRegister(i.operands.register, reg_ctx, arch)}),
+        => |i| try writer.print(" {}", .{fmtRegister(i.register, reg_ctx, arch)}),
         .nop => {},
-        .register => |i| try writer.print(" {} {}", .{ fmtRegister(i.operands.register, reg_ctx, arch), fmtRegister(i.operands.target_register, reg_ctx, arch) }),
+        .register => |i| try writer.print(" {} {}", .{ fmtRegister(i.register, reg_ctx, arch), fmtRegister(i.target_register, reg_ctx, arch) }),
         .remember_state => {},
         .restore_state => {},
-        .def_cfa => |i| try writer.print(" {} {d:<1}", .{ fmtRegister(i.operands.register, reg_ctx, arch), @as(i64, @intCast(i.operands.offset)) }),
-        .def_cfa_sf => |i| try writer.print(" {} {d:<1}", .{ fmtRegister(i.operands.register, reg_ctx, arch), i.operands.offset * cie.data_alignment_factor }),
-        .def_cfa_register => |i| try writer.print(" {}", .{fmtRegister(i.operands.register, reg_ctx, arch)}),
-        .def_cfa_offset => |i| try writer.print(" {d:<1}", .{@as(i64, @intCast(i.operands.offset))}),
-        .def_cfa_offset_sf => |i| try writer.print(" {d:<1}", .{i.operands.offset * cie.data_alignment_factor}),
+        .def_cfa => |i| try writer.print(" {} {d:<1}", .{ fmtRegister(i.register, reg_ctx, arch), @as(i64, @intCast(i.offset)) }),
+        .def_cfa_sf => |i| try writer.print(" {} {d:<1}", .{ fmtRegister(i.register, reg_ctx, arch), i.offset * cie.data_alignment_factor }),
+        .def_cfa_register => |i| try writer.print(" {}", .{fmtRegister(i.register, reg_ctx, arch)}),
+        .def_cfa_offset => |i| try writer.print(" {d:<1}", .{@as(i64, @intCast(i.offset))}),
+        .def_cfa_offset_sf => |i| try writer.print(" {d:<1}", .{i.offset * cie.data_alignment_factor}),
         .def_cfa_expression => |i| {
             try writer.writeByte(' ');
-            try writeExpression(writer, i.operands.block, arch, expression_context, reg_ctx, addr_size_bytes, endian);
+            try writeExpression(writer, i.block, arch, expression_context, reg_ctx, addr_size_bytes, endian);
         },
         .expression => |i| {
-            try writer.print(" {} ", .{fmtRegister(i.operands.register, reg_ctx, arch)});
-            try writeExpression(writer, i.operands.block, arch, expression_context, reg_ctx, addr_size_bytes, endian);
+            try writer.print(" {} ", .{fmtRegister(i.register, reg_ctx, arch)});
+            try writeExpression(writer, i.block, arch, expression_context, reg_ctx, addr_size_bytes, endian);
         },
         .val_offset => {},
         .val_offset_sf => {},

--- a/src/DwarfDump.zig
+++ b/src/DwarfDump.zig
@@ -916,13 +916,19 @@ pub fn printEhFrames(self: DwarfDump, writer: anytype, llvm_compatibility: bool)
                 name: []const u8,
                 frame_type: dwarf.DwarfSection,
             }{
-                .{ .name = "__debug_frame", .frame_type = .debug_frame },
-                .{ .name = "__eh_frame", .frame_type = .eh_frame },
+                .{
+                    .name = "__debug_frame",
+                    .frame_type = .debug_frame,
+                },
+                .{
+                    .name = "__eh_frame",
+                    .frame_type = .eh_frame,
+                },
             };
 
             for (sections) |section| {
-                try writer.print("\n{s} contents:\n\n", .{section.name});
-                if (macho.getSectionByName("__TEXT", section.name)) |s| {
+                try writer.print("\n.{s} contents:\n\n", .{@tagName(section.frame_type)});
+                if (macho.getSectionByName("__DWARF", section.name)) |s| {
                     try self.printEhFrame(
                         writer,
                         llvm_compatibility,
@@ -1024,7 +1030,7 @@ fn writeCie(
                     else => unreachable,
                 }),
             });
-        }
+        },
     }
 
     const cie = &cie_with_header.cie;
@@ -1106,7 +1112,7 @@ fn writeFde(
                 fde.pc_begin,
                 fde.pc_begin + fde.pc_range,
             });
-        }
+        },
     }
 
     try writeFormat(writer, cie_with_header.header.is_64, false);

--- a/src/DwarfDump.zig
+++ b/src/DwarfDump.zig
@@ -1217,6 +1217,8 @@ fn writeRow(
     addr_size: u8,
     endian: std.builtin.Endian,
 ) !void {
+    const columns = vm.rowColumns(row);
+
     var wrote_anything = false;
     if (try writeColumnRule(
         row.cfa,
@@ -1228,12 +1230,11 @@ fn writeRow(
         addr_size,
         endian,
     )) {
-        try writer.writeAll(": ");
+        if (columns.len > 0) try writer.writeAll(": ");
         wrote_anything = true;
     }
 
     // llvm-dwarfdump prints columns sorted by register number
-    const columns = vm.rowColumns(row);
     var num_printed: usize = 0;
     for (0..256) |register| {
         for (columns) |column| {
@@ -1538,8 +1539,8 @@ pub fn writeRegisterName(
             },
             .aarch64 => {
                 switch (reg_number) {
-                    0...30 => try writer.print("X{}", .{reg_number}),
-                    31 => try writer.writeAll("SP"),
+                    0...30 => try writer.print("W{}", .{reg_number}),
+                    31 => try writer.writeAll("WSP"),
                     32 => try writer.writeAll("PC"),
                     33 => try writer.writeAll("ELR_mode"),
                     34 => try writer.writeAll("RA_SIGN_STATE"),
@@ -1557,9 +1558,6 @@ pub fn writeRegisterName(
                     else => try writeUnknownReg(writer, reg_number),
                 }
             },
-
-            // TODO: Add aarch64
-
             else => try writeUnknownReg(writer, reg_number),
         }
     } else try writeUnknownReg(writer, reg_number);

--- a/src/DwarfDump.zig
+++ b/src/DwarfDump.zig
@@ -90,7 +90,7 @@ pub fn printCompileUnits(self: DwarfDump, writer: anytype) !void {
             while (try attr_it.next()) |attr| {
                 try formatIndent(children * 2, writer);
                 try writer.print("{s: <22}{s: <30}", .{ "", try formatATName(attr.value.name, &buffer) });
-                try formatIndent(max_indent - children * 2, writer);
+                try formatIndent(max_indent - @min(max_indent, children * 2), writer);
 
                 switch (attr.value.name) {
                     dwarf.AT.stmt_list,

--- a/src/DwarfDump.zig
+++ b/src/DwarfDump.zig
@@ -1281,7 +1281,7 @@ fn writeExpression(
                     const StackMachine = dwarf.expressions.StackMachine(.{
                         .addr_size = size,
                         .endian = e,
-                        .call_frame_mode = true,
+                        .call_frame_context = true,
                     });
 
                     const reader = stream.reader();
@@ -1293,7 +1293,7 @@ fn writeExpression(
                             try writer.print("DW_OP_{s}", .{opcode_name});
                         } else {
                             // TODO: See how llvm-dwarfdump prints these?
-                            if (opcode >= dwarf.OP.lo_user and opcode <= dwarf.OP.lo_user) {
+                            if (opcode >= dwarf.OP.lo_user and opcode <= dwarf.OP.hi_user) {
                                 try writer.print("<unknown vendor opcode: 0x{x}>", .{opcode});
                             } else {
                                 try writer.print("<invalid opcode: 0x{x}>", .{opcode});

--- a/src/DwarfDump.zig
+++ b/src/DwarfDump.zig
@@ -3,6 +3,7 @@ const DwarfDump = @This();
 const std = @import("std");
 const assert = std.debug.assert;
 const dwarf = std.dwarf;
+const abi = dwarf.abi;
 const leb = std.leb;
 const log = std.log;
 const fs = std.fs;
@@ -11,6 +12,7 @@ const mem = std.mem;
 const Allocator = mem.Allocator;
 const AbbrevLookupTable = std.AutoHashMap(u64, struct { pos: usize, len: usize });
 const Context = @import("Context.zig");
+const VirtualMachine = dwarf.call_frame.VirtualMachine;
 
 gpa: Allocator,
 ctx: *Context,
@@ -835,267 +837,523 @@ fn getDwarfString(ctx: *const Context, off: u64) []const u8 {
     return mem.sliceTo(@ptrCast([*:0]const u8, debug_str.ptr + off), 0);
 }
 
-pub fn printEhFrame(self: DwarfDump, writer: anytype) !void {
+const FrameType = enum {
+    eh,
+    dwarf32,
+    dwarf64,
+
+    pub fn headerFormat(self: FrameType) []const u8 {
+        return switch (self) {
+            .dwarf64 => "{x:0>16}",
+            else => "{x:0>8}",
+        };
+    }
+};
+
+const CieWithHeader = struct {
+    cie: dwarf.CommonInformationEntry,
+    header: DwarfHeader,
+
+    vm: VirtualMachine = .{},
+
+    // Instead of re-running the CIE instructions to print each FDE, the vm state
+    // is restored to the post-CIE state instead.
+    vm_snapshot_columns: usize = undefined,
+    vm_snapshot_row: VirtualMachine.Row = undefined,
+
+    pub fn deinit(self: *CieWithHeader, allocator: mem.Allocator) void {
+        self.vm.deinit(allocator);
+    }
+};
+
+const WriteOptions = struct {
+    llvm_compatibility: bool,
+    frame_type: FrameType,
+    addr_size: u8,
+    endian: std.builtin.Endian,
+};
+
+const Section = struct {
+    data: []const u8,
+    offset: u64,
+    frame_type: FrameType,
+};
+
+pub fn printEhFrames(self: DwarfDump, writer: anytype, llvm_compatibility: bool) !void {
     switch (self.ctx.tag) {
-        .elf => return error.Unimplemented,
-        .macho => {},
-    }
+        .elf => {
+            const elf = self.ctx.cast(Context.Elf).?;
+            const sections = [_]struct {
+                name: []const u8,
+                section: ?std.elf.Elf64_Shdr,
+                data: ?[]const u8,
+                frame_type: FrameType,
+            }{
+                .{
+                    .name = ".debug_frame",
+                    .section = elf.debug_frame,
+                    .data = elf.getDebugFrameData(),
+                    .frame_type = .dwarf32,
+                }, // TODO: Detect dwarf64
+                .{
+                    .name = ".eh_frame",
+                    .section = elf.eh_frame,
+                    .data = elf.getEhFrameData(),
+                    .frame_type = .eh,
+                },
+            };
 
-    const macho = self.ctx.cast(Context.MachO).?;
-    const addr_size: u8 = 8;
-    const sect = macho.getSectionByName("__TEXT", "__eh_frame") orelse {
-        try writer.print("No __TEXT,__eh_frame section.\n", .{});
-        return;
-    };
+            for (sections) |section| {
+                try writer.print("{s} contents:\n\n", .{section.name});
+                if (section.section) |s| {
+                    if (s.sh_type != std.elf.SHT_NULL and s.sh_type != std.elf.SHT_NOBITS) {
+                        try self.printEhFrame(writer, llvm_compatibility, .{
+                            .data = section.data.?,
+                            .offset = s.sh_offset,
+                            .frame_type = section.frame_type,
+                        });
+                    }
+                }
 
-    var cies = std.AutoArrayHashMap(u64, CommonInformationEntry).init(self.gpa);
-    defer cies.deinit();
+                try writer.writeAll("\n");
+            }
+        },
+        .macho => {
+            const macho = self.ctx.cast(Context.MachO).?;
+            const sections = [_]struct {
+                name: []const u8,
+                frame_type: FrameType,
+            }{
+                .{ .name = "__debug_frame", .frame_type = .dwarf32 }, // TODO: Detect dwarf64
+                .{ .name = "__eh_frame", .frame_type = .eh },
+            };
 
-    var fdes = std.ArrayList(struct { fde: FrameDescriptionEntry, offset: u64 }).init(self.gpa);
-    defer fdes.deinit();
+            for (sections) |section| {
+                try writer.print("{s} contents:\n\n", .{section.name});
+                if (macho.getSectionByName("__TEXT", section.name)) |s| {
+                    try self.printEhFrame(writer, llvm_compatibility, .{
+                        .data = macho.getSectionData(s),
+                        .offset = s.offset,
+                        .frame_type = section.frame_type,
+                    });
+                }
 
-    const data = macho.getSectionData(sect);
-    var offset: u64 = 0;
-
-    while (true) {
-        if (offset >= data.len) break;
-
-        const header = try DwarfHeader.parse(data[offset..]);
-        var tmp_offset = header.size();
-
-        const id = if (header.is64Bit())
-            mem.readIntLittle(u64, data[offset + tmp_offset ..][0..8])
-        else
-            mem.readIntLittle(u32, data[offset + tmp_offset ..][0..4]);
-        tmp_offset += if (header.is64Bit()) 8 else 4;
-
-        if (id == 0) { // TODO hard-coding for now
-            // CIE
-            const cie = try CommonInformationEntry.parse(header, id, addr_size, data[offset + tmp_offset ..]);
-            try cies.putNoClobber(offset, cie);
-            offset += cie.header.length + cie.header.size();
-        } else {
-            // FDE
-            const fde = try FrameDescriptionEntry.parse(header, id, addr_size, data[offset + tmp_offset ..]);
-            try fdes.append(.{ .fde = fde, .offset = offset });
-            offset += fde.header.length + fde.header.size();
-        }
-    }
-
-    try writer.writeAll("__TEXT,__eh_frame contents:\n");
-
-    for (cies.keys()) |cie_offset| {
-        const cie = cies.get(cie_offset).?;
-
-        try writer.writeAll("\nCIE:\n");
-        try writer.print("  {s: <30}: {d}\n", .{ "Length", cie.header.length });
-        try writer.print("  {s: <30}: {d}\n", .{ "Id", cie.id });
-        try writer.print("  {s: <30}: {d}\n", .{ "Version", cie.version });
-        try writer.print("  {s: <30}: {s}\n", .{ "Augmentation", cie.augmentation_str });
-        try writer.print("  {s: <30}: {d}\n", .{ "Code Alignment Factor", cie.code_alignment_factor });
-        try writer.print("  {s: <30}: {d}\n", .{ "Data Alignment Factor", cie.data_alignment_factor });
-        try writer.print("  {s: <30}: {d}\n", .{ "Return Address Register", cie.return_address_register });
-        try writer.print("  {s: <30}: {d}\n", .{ "Augmentation Length", cie.augmentation_data.len });
-        try writer.print("  {s: <30}: 0x{x}\n", .{ "FDE Pointer Encoding", cie.fde_pointer_encoding });
-        try writer.print("  {s: <30}: 0x{x}\n", .{ "LSDA Pointer Encoding", cie.lsda_pointer_encoding });
-
-        if (cie.personality) |_| {
-            try writer.print("  {s: <30}: 0x{x}\n", .{ "Personality", cie.personality.? });
-            try writer.print("  {s: <30}: 0x{x}\n", .{ "Personality Encoding", cie.personality_encoding.? });
-        }
-
-        try writer.print("  {s: <30}: 0x{x}\n", .{ "Augmentation Data", std.fmt.fmtSliceHexLower(cie.augmentation_data) });
-        try writer.print("  {s: <30}: 0x{x}\n", .{
-            "Initial Instructions",
-            std.fmt.fmtSliceHexLower(cie.initial_instructions),
-        });
-
-        for (fdes.items) |fde_with_offset| {
-            const fde = fde_with_offset.fde;
-            if (fde_with_offset.offset + fde.header.size() - fde.cie_pointer != cie_offset) continue;
-
-            try writer.writeAll("\nFDE:\n");
-            try writer.print("  {s: <30}: {d}\n", .{ "Length", fde.header.length });
-            try writer.print("  {s: <30}: 0x{x}\n", .{ "CIE Pointer", fde.cie_pointer });
-            try writer.print("  {s: <30}: 0x{x}\n", .{ "PC Begin", fde.pc_begin });
-            try writer.print("  {s: <30}: {d}\n", .{ "PC Range", fde.pc_range });
-            try writer.print("  {s: <30}: {d}\n", .{ "Augmentation Length", fde.augmentation_data.len });
-            try writer.print("  {s: <30}: 0x{x}\n", .{ "Instructions", std.fmt.fmtSliceHexLower(fde.instructions) });
-        }
+                try writer.writeAll("\n");
+            }
+        },
     }
 }
 
-const CommonInformationEntry = struct {
-    header: DwarfHeader,
-    id: u64,
-    version: u8,
-    augmentation_str: []const u8,
-    code_alignment_factor: u64,
-    data_alignment_factor: i64,
-    return_address_register: u64,
-    augmentation_data: []const u8,
-    fde_pointer_encoding: u32,
-    lsda_pointer_encoding: u32,
-    personality: ?u64,
-    personality_encoding: ?u8,
-    initial_instructions: []const u8,
+pub fn printEhFrame(self: DwarfDump, writer: anytype, llvm_compatibility: bool, section: Section) !void {
+    const write_options = WriteOptions{
+        .llvm_compatibility = llvm_compatibility,
+        .frame_type = section.frame_type,
 
-    fn parse(header: DwarfHeader, id: u64, addr_size: u8, buffer: []const u8) !CommonInformationEntry {
-        var stream = std.io.fixedBufferStream(buffer);
-        var creader = std.io.countingReader(stream.reader());
-        const reader = creader.reader();
-
-        const version = try reader.readByte();
-        const augmentation_str = blk: {
-            const augmentation = mem.sliceTo(@ptrCast([*:0]const u8, buffer.ptr + creader.bytes_read), 0);
-            stream.pos += augmentation.len + 1;
-            creader.bytes_read += augmentation.len + 1;
-            break :blk augmentation;
-        };
-
-        const code_alignment_factor = try leb.readULEB128(u64, reader);
-        const data_alignment_factor = try leb.readILEB128(i64, reader);
-        const return_address_register = try leb.readULEB128(u64, reader);
-
-        var augmentation_start: usize = 0;
-        var augmentation_length: usize = 0;
-        var augmentation_data: []const u8 = &[0]u8{};
-        var fde_pointer_encoding: u32 = 0;
-        var lsda_pointer_encoding: u32 = 0;
-        var personality: ?u64 = null;
-        var personality_encoding: ?u8 = null;
-
-        for (augmentation_str, 0..) |ch, i| switch (ch) {
-            'z' => if (i > 0) {
-                return error.MalformedAugmentationString;
-            } else {
-                augmentation_length = try leb.readULEB128(u64, reader);
-                augmentation_start = creader.bytes_read;
-            },
-            'R' => {
-                fde_pointer_encoding = try reader.readByte();
-            },
-            'P' => {
-                personality_encoding = try reader.readByte();
-                personality = try getEncodedPointer(personality_encoding.?, addr_size, 0, reader); // TODO resolve relocs
-            },
-            'L' => {
-                lsda_pointer_encoding = try reader.readByte();
-            },
-            'S', 'B', 'G' => {},
-            else => return error.UnknownAugmentationStringValue,
-        };
-
-        if (augmentation_length > 0) {
-            augmentation_data = buffer[augmentation_start..][0..augmentation_length];
-        }
-
-        const nread = creader.bytes_read + header.size() + (if (header.is64Bit()) @as(u64, 8) else 4);
-        const initial_instructions = buffer[creader.bytes_read..][0 .. header.length + header.size() - nread];
-
-        return CommonInformationEntry{
-            .header = header,
-            .id = id,
-            .version = version,
-            .augmentation_str = augmentation_str,
-            .code_alignment_factor = code_alignment_factor,
-            .data_alignment_factor = data_alignment_factor,
-            .return_address_register = return_address_register,
-            .augmentation_data = augmentation_data,
-            .fde_pointer_encoding = fde_pointer_encoding,
-            .lsda_pointer_encoding = lsda_pointer_encoding,
-            .personality = personality,
-            .personality_encoding = personality_encoding,
-            .initial_instructions = initial_instructions,
-        };
-    }
-};
-
-const FrameDescriptionEntry = struct {
-    header: DwarfHeader,
-    cie_pointer: u64,
-    pc_begin: u64,
-    pc_range: u64,
-    augmentation_data: []const u8,
-    instructions: []const u8,
-
-    fn parse(header: DwarfHeader, cie_pointer: u64, addr_size: u16, buffer: []const u8) !FrameDescriptionEntry {
-        var stream = std.io.fixedBufferStream(buffer);
-        var creader = std.io.countingReader(stream.reader());
-        const reader = creader.reader();
-
-        const pc_begin = if (addr_size == 8) try reader.readIntLittle(u64) else try reader.readIntLittle(u32);
-        const pc_range = if (addr_size == 8) try reader.readIntLittle(u64) else try reader.readIntLittle(u32);
-
-        const augmentation_length = try leb.readULEB128(u64, reader);
-        const augmentation_data = buffer[creader.bytes_read..][0..augmentation_length];
-        creader.bytes_read += augmentation_length;
-        stream.pos += augmentation_length;
-
-        const nread = creader.bytes_read + header.size() + (if (header.is64Bit()) @as(u64, 8) else 4);
-        const instructions = buffer[creader.bytes_read..][0 .. header.length + header.size() - nread];
-
-        return FrameDescriptionEntry{
-            .header = header,
-            .cie_pointer = cie_pointer,
-            .pc_begin = pc_begin,
-            .pc_range = pc_range,
-            .augmentation_data = augmentation_data,
-            .instructions = instructions,
-        };
-    }
-};
-
-const EH_PE = struct {
-    const absptr = 0x00;
-    const uleb128 = 0x01;
-    const udata2 = 0x02;
-    const udata4 = 0x03;
-    const udata8 = 0x04;
-    const sleb128 = 0x09;
-    const sdata2 = 0x0A;
-    const sdata4 = 0x0B;
-    const sdata8 = 0x0C;
-    const pcrel = 0x10;
-    const textrel = 0x20;
-    const datarel = 0x30;
-    const funcrel = 0x40;
-    const aligned = 0x50;
-    const indirect = 0x80;
-    const omit = 0xFF;
-};
-
-fn getEncodedPointer(enc: u8, addr_size: u8, pcrel_offset: i64, reader: anytype) !?u64 {
-    if (enc == EH_PE.omit) return null;
-
-    var ptr: i64 = switch (enc & 0x0F) {
-        EH_PE.absptr => switch (addr_size) {
-            2 => @bitCast(i16, try reader.readIntLittle(u16)),
-            4 => @bitCast(i32, try reader.readIntLittle(u32)),
-            8 => @bitCast(i64, try reader.readIntLittle(u64)),
-            else => return null,
-        },
-        EH_PE.udata2 => @bitCast(i16, try reader.readIntLittle(u16)),
-        EH_PE.udata4 => @bitCast(i32, try reader.readIntLittle(u32)),
-        EH_PE.udata8 => @bitCast(i64, try reader.readIntLittle(u64)),
-        EH_PE.uleb128 => @bitCast(i64, try leb.readULEB128(u64, reader)),
-        EH_PE.sdata2 => try reader.readIntLittle(i16),
-        EH_PE.sdata4 => try reader.readIntLittle(i32),
-        EH_PE.sdata8 => try reader.readIntLittle(i64),
-        EH_PE.sleb128 => try leb.readILEB128(i64, reader),
-        else => return null,
+        // TODO: Use the addr size / endianness of the file, provide in section
+        .addr_size = @sizeOf(usize),
+        .endian = .Little,
     };
 
-    switch (enc & 0x70) {
-        EH_PE.absptr => {},
-        EH_PE.pcrel => ptr += pcrel_offset,
-        EH_PE.datarel,
-        EH_PE.textrel,
-        EH_PE.funcrel,
-        EH_PE.aligned,
-        => return null,
-        else => return null,
+    var cies = std.AutoArrayHashMap(u64, CieWithHeader).init(self.gpa);
+    defer {
+        for (cies.keys()) |cie_offset| cies.getPtr(cie_offset).?.deinit(self.gpa);
+        cies.deinit();
     }
 
-    return @bitCast(u64, ptr);
+    var offset: u64 = 0;
+    while (true) {
+        if (offset >= section.data.len) break;
+
+        const header = try DwarfHeader.parse(section.data[offset..]);
+        if (header.length == 0) {
+            try writer.print("{x:0>8} ZERO terminator", .{offset});
+            break;
+        }
+
+        var id_offset = header.size();
+        const id = if (header.is64Bit())
+            mem.readIntLittle(u64, section.data[offset + id_offset ..][0..8])
+        else
+            mem.readIntLittle(u32, section.data[offset + id_offset ..][0..4]);
+        const id_len = @as(u8, if (header.is64Bit()) 8 else 4);
+        const tmp_offset = id_offset + id_len;
+        const entry_bytes = section.data[offset + tmp_offset ..][0 .. header.length - id_len];
+
+        // TODO: Support CommonInformationEntry.dwarf32_id, CommonInformationEntry.dwarf64_id
+
+        if (id == 0) {
+            const cie = try dwarf.CommonInformationEntry.parse(
+                entry_bytes,
+                @ptrToInt(section.data.ptr),
+                section.offset,
+                false,
+                offset,
+                write_options.addr_size,
+                write_options.endian,
+            );
+
+            const entry = try cies.getOrPut(offset);
+            assert(!entry.found_existing);
+            entry.value_ptr.* = .{ .cie = cie, .header = header };
+
+            try self.writeCie(writer, write_options, entry.value_ptr);
+        } else {
+            const cie_offset = (offset + id_offset) - id;
+            const cie_with_header = cies.getPtr(cie_offset) orelse return error.InvalidFDE;
+            const fde = try dwarf.FrameDescriptionEntry.parse(
+                entry_bytes,
+                @ptrToInt(section.data.ptr),
+                section.offset,
+                false,
+                cie_with_header.cie,
+                write_options.addr_size,
+                write_options.endian,
+            );
+
+            try self.writeFde(writer, write_options, cie_with_header, offset, header, fde);
+        }
+
+        offset += id_offset + header.length;
+    }
+}
+
+fn writeCie(
+    self: DwarfDump,
+    writer: anytype,
+    options: WriteOptions,
+    cie_with_header: *CieWithHeader,
+) !void {
+    switch (options.frame_type) {
+        inline else => |frame_type| {
+            const length_fmt = comptime frame_type.headerFormat();
+            try writer.print("{x:0>8} " ++ length_fmt ++ " " ++ length_fmt ++ " CIE\n", .{
+                cie_with_header.cie.length_offset,
+                cie_with_header.header.length,
+                switch (frame_type) {
+                    .eh => dwarf.CommonInformationEntry.eh_id,
+                    .dwarf32 => dwarf.CommonInformationEntry.dwarf32_id,
+                    .dwarf64 => dwarf.CommonInformationEntry.dwarf64_id,
+                },
+            });
+        },
+    }
+
+    const cie = &cie_with_header.cie;
+    try writeFormat(writer, options.frame_type, true);
+    try writer.print("  {s: <23}{}\n", .{ "Version:", cie.version });
+    try writer.print("  {s: <23}\"{s}\"\n", .{ "Augmentation:", cie.aug_str });
+    try writer.print("  {s: <23}{}\n", .{ "Code alignment factor:", cie.code_alignment_factor });
+    try writer.print("  {s: <23}{}\n", .{ "Data alignment factor:", cie.data_alignment_factor });
+    try writer.print("  {s: <23}{}\n", .{ "Return address column:", cie.return_address_register });
+
+    // Oddly llvm-dwarfdump does not align this field with the rest
+    if (cie.personality_routine_pointer) |p| try writer.print("  {s: <21}{x:0>16}\n", .{ "Personality Address:", p });
+
+    if (cie.aug_data.len > 0) {
+        try writer.print("  {s: <22}", .{"Augmentation data:"});
+        for (cie.aug_data) |byte| {
+            try writer.print(" {X:0>2}", .{byte});
+        }
+        try writer.writeByte('\n');
+    }
+
+    if (!options.llvm_compatibility) {
+        try writer.writeAll("\n");
+        if (cie.personality_enc) |p| try writer.print("  {s: <23}{X}\n", .{ "Personality Pointer Encoding:", p });
+        try writer.print("  {s: <23}{X}\n", .{ "LSDA Pointer Encoding:", cie.lsda_pointer_enc });
+        try writer.print("  {s: <23}{X}\n", .{ "FDE Pointer Encoding:", cie.fde_pointer_enc });
+    }
+
+    try writer.writeAll("\n");
+
+    {
+        var instruction_stream = std.io.fixedBufferStream(cie.initial_instructions);
+        while (instruction_stream.pos < instruction_stream.buffer.len) {
+            const instruction = try dwarf.call_frame.Instruction.read(&instruction_stream, options.addr_size, options.endian);
+            const opcode = std.meta.activeTag(instruction);
+            try writer.print("  DW_CFA_{s}:", .{@tagName(opcode)});
+            try writeOperands(instruction, writer, cie.*, self.ctx.getArch(), options.addr_size, options.endian);
+            _ = try cie_with_header.vm.step(self.gpa, cie.*, true, instruction);
+            try writer.writeByte('\n');
+        }
+    }
+
+    try writer.writeAll("\n");
+    if (cie_with_header.vm.current_row.cfa.rule != .default) try writer.writeAll("  ");
+    try self.writeRow(writer, cie_with_header.vm, cie_with_header.vm.current_row, options.addr_size, options.endian);
+    try writer.writeByte('\n');
+
+    cie_with_header.vm_snapshot_columns = cie_with_header.vm.columns.items.len;
+    cie_with_header.vm_snapshot_row = cie_with_header.vm.current_row;
+}
+
+fn writeFde(
+    self: DwarfDump,
+    writer: anytype,
+    options: WriteOptions,
+    cie_with_header: *CieWithHeader,
+    offset: u64,
+    header: DwarfHeader,
+    fde: dwarf.FrameDescriptionEntry,
+) !void {
+    const cie = &cie_with_header.cie;
+
+    switch (options.frame_type) {
+        inline else => |frame_type| {
+            // TODO: Print <invalid offset> for cie if it didn't point to an actual CIE
+            const length_fmt = comptime frame_type.headerFormat();
+            try writer.print("{x:0>8} " ++ length_fmt ++ " " ++ length_fmt ++ " FDE cie={x:0>8} pc={x:0>8}...{x:0>8}\n", .{
+                offset,
+                header.length,
+                (offset + header.size()) - fde.cie_length_offset,
+                fde.cie_length_offset,
+                fde.pc_begin,
+                fde.pc_begin + fde.pc_range,
+            });
+        },
+    }
+
+    try writeFormat(writer, options.frame_type, false);
+    if (fde.lsda_pointer) |p| try writer.print("  LSDA Address: {x:0>16}\n", .{p});
+
+    if (!options.llvm_compatibility) {
+        if (fde.aug_data.len > 0) try writer.print("  {s: <23}{}\n", .{ "Augmentation data:", std.fmt.fmtSliceHexUpper(cie.aug_data) });
+    }
+
+    var instruction_stream = std.io.fixedBufferStream(fde.instructions);
+
+    // First pass to print instructions and their operands
+    while (instruction_stream.pos < instruction_stream.buffer.len) {
+        const instruction = try dwarf.call_frame.Instruction.read(&instruction_stream, options.addr_size, options.endian);
+        const opcode = std.meta.activeTag(instruction);
+        try writer.print("  DW_CFA_{s}:", .{@tagName(opcode)});
+        try writeOperands(instruction, writer, cie.*, self.ctx.getArch(), options.addr_size, options.endian);
+        try writer.writeByte('\n');
+    }
+
+    try writer.writeByte('\n');
+
+    // Second pass to run them and print the generated table
+    instruction_stream.pos = 0;
+    while (instruction_stream.pos < instruction_stream.buffer.len) {
+        const instruction = try dwarf.call_frame.Instruction.read(&instruction_stream, options.addr_size, options.endian);
+        var prev_row = try cie_with_header.vm.step(self.gpa, cie.*, false, instruction);
+        if (cie_with_header.vm.current_row.offset != prev_row.offset) {
+            try writer.print("  0x{x}: ", .{fde.pc_begin + prev_row.offset});
+            try self.writeRow(writer, cie_with_header.vm, prev_row, options.addr_size, options.endian);
+        }
+    }
+
+    try writer.print("  0x{x}: ", .{fde.pc_begin + cie_with_header.vm.current_row.offset});
+    try self.writeRow(writer, cie_with_header.vm, cie_with_header.vm.current_row, options.addr_size, options.endian);
+
+    // Restore the VM state to the result of the initial CIE instructions
+    cie_with_header.vm.columns.items.len = cie_with_header.vm_snapshot_columns;
+    cie_with_header.vm.current_row = cie_with_header.vm_snapshot_row;
+    cie_with_header.vm.cie_row = null;
+
+    try writer.writeByte('\n');
+}
+
+fn writeRow(self: DwarfDump, writer: anytype, vm: VirtualMachine, row: VirtualMachine.Row, addr_size: u8, endian: std.builtin.Endian) !void {
+    var wrote_anything = false;
+    if (try writeColumnRule(row.cfa, writer, true, self.ctx.getArch(), addr_size, endian)) {
+        try writer.writeAll(": ");
+        wrote_anything = true;
+    }
+
+    // llvm-dwarfdump prints columns sorted by register number
+    const columns = vm.rowColumns(row);
+    var num_printed: usize = 0;
+    for (0..256) |register| {
+        for (columns) |column| {
+            if (column.register == @intCast(u8, register)) {
+                if (try writeColumnRule(column, writer, false, self.ctx.getArch(), addr_size, endian)) {
+                    if (num_printed != columns.len - 1) {
+                        try writer.writeAll(", ");
+                    }
+                    wrote_anything = true;
+                }
+
+                num_printed += 1;
+            }
+        }
+
+        if (num_printed == columns.len) break;
+    }
+
+    if (wrote_anything) try writer.writeByte('\n');
+}
+
+pub fn writeColumnRule(
+    column: VirtualMachine.Column,
+    writer: anytype,
+    is_cfa: bool,
+    arch: ?std.Target.Cpu.Arch,
+    addr_size_bytes: u8,
+    endian: std.builtin.Endian,
+) !bool {
+    if (column.rule == .default) return false;
+
+    if (is_cfa) {
+        try writer.writeAll("CFA");
+    } else {
+        try abi.writeRegisterName(writer, arch, column.register.?);
+    }
+
+    try writer.writeByte('=');
+    switch (column.rule) {
+        .default => {},
+        .undefined => try writer.writeAll("undefined"),
+        .same_value => try writer.writeAll("S"),
+        .offset, .val_offset => |offset| {
+            if (offset == 0) {
+                if (is_cfa) {
+                    if (column.register) |cfa_register| {
+                        try writer.print("{}", .{abi.fmtRegister(cfa_register, arch)});
+                    } else {
+                        try writer.writeAll("undefined");
+                    }
+                } else {
+                    try writer.writeAll("[CFA]");
+                }
+            } else {
+                if (is_cfa) {
+                    if (column.register) |cfa_register| {
+                        try writer.print("{}{d:<1}", .{ abi.fmtRegister(cfa_register, arch), offset });
+                    } else {
+                        try writer.print("undefined{d:<1}", .{offset});
+                    }
+                } else {
+                    try writer.print("[CFA{d:<1}]", .{offset});
+                }
+            }
+        },
+        .register => |register| try abi.writeRegisterName(writer, arch, register),
+        .expression => |expression| {
+            if (!is_cfa) try writer.writeByte('[');
+            try writeExpression(writer, expression, arch, addr_size_bytes, endian);
+            if (!is_cfa) try writer.writeByte(']');
+        },
+        .val_expression => try writer.writeAll("TODO(val_expression)"),
+        .architectural => try writer.writeAll("TODO(architectural)"),
+    }
+
+    return true;
+}
+
+fn writeExpression(
+    writer: anytype,
+    block: []const u8,
+    arch: ?std.Target.Cpu.Arch,
+    addr_size_bytes: u8,
+    endian: std.builtin.Endian,
+) !void {
+    var stream = std.io.fixedBufferStream(block);
+
+    // Generate a lookup table from opcode value to name
+    const opcode_lut_len = 256;
+    const opcode_lut: [opcode_lut_len]?[]const u8 = comptime blk: {
+        var lut: [opcode_lut_len]?[]const u8 = [_]?[]const u8{null} ** opcode_lut_len;
+        for (@typeInfo(dwarf.OP).Struct.decls) |decl| {
+            lut[@as(u8, @field(dwarf.OP, decl.name))] = decl.name;
+        }
+
+        break :blk lut;
+    };
+
+    switch (endian) {
+        inline .Little, .Big => |e| {
+            switch (addr_size_bytes) {
+                inline 2, 4, 8 => |size| {
+                    const StackMachine = dwarf.expressions.StackMachine(.{
+                        .addr_size = size,
+                        .endian = e,
+                        .call_frame_mode = true,
+                    });
+
+                    const reader = stream.reader();
+                    while (stream.pos < stream.buffer.len) {
+                        if (stream.pos > 0) try writer.writeAll(", ");
+
+                        const opcode = try reader.readByte();
+                        if (opcode_lut[opcode]) |opcode_name| {
+                            try writer.print("DW_OP_{s}", .{opcode_name});
+                        } else {
+                            // TODO: See how llvm-dwarfdump prints these?
+                            if (opcode >= dwarf.OP.lo_user and opcode <= dwarf.OP.lo_user) {
+                                try writer.print("<unknown vendor opcode: 0x{x}>", .{opcode});
+                            } else {
+                                try writer.print("<invalid opcode: 0x{x}>", .{opcode});
+                            }
+                        }
+
+                        if (try StackMachine.readOperand(&stream, opcode)) |value| {
+                            switch (value) {
+                                .generic => {}, // Constant values are implied by the opcode name
+                                .register => |v| try writer.print(" {}", .{abi.fmtRegister(v, arch)}),
+                                .base_register => |v| try writer.print(" {}{d:<1}", .{ abi.fmtRegister(v.base_register, arch), v.offset }),
+                                else => try writer.print(" TODO({s})", .{@tagName(value)}),
+                            }
+                        }
+                    }
+                },
+                else => return error.InvalidAddrSize,
+            }
+        },
+    }
+}
+
+fn writeOperands(
+    instruction: dwarf.call_frame.Instruction,
+    writer: anytype,
+    cie: dwarf.CommonInformationEntry,
+    arch: ?std.Target.Cpu.Arch,
+    addr_size_bytes: u8,
+    endian: std.builtin.Endian,
+) !void {
+    switch (instruction) {
+        .set_loc => |i| try writer.print(" 0x{x}", .{i.operands.address}),
+        inline .advance_loc,
+        .advance_loc1,
+        .advance_loc2,
+        .advance_loc4,
+        => |i| try writer.print(" {}", .{i.operands.delta * cie.code_alignment_factor}),
+        inline .offset,
+        .offset_extended,
+        .offset_extended_sf,
+        => |i| try writer.print(" {} {d}", .{
+            abi.fmtRegister(i.operands.register, arch),
+            @intCast(i64, i.operands.offset) * cie.data_alignment_factor,
+        }),
+        inline .restore,
+        .restore_extended,
+        .undefined,
+        .same_value,
+        => |i| try writer.print(" {}", .{abi.fmtRegister(i.operands.register, arch)}),
+        .nop => {},
+        .register => |i| try writer.print(" {} {}", .{ abi.fmtRegister(i.operands.register, arch), abi.fmtRegister(i.operands.target_register, arch) }),
+        .remember_state => {},
+        .restore_state => {},
+        .def_cfa => |i| try writer.print(" {} {d:<1}", .{ abi.fmtRegister(i.operands.register, arch), @intCast(i64, i.operands.offset) }),
+        .def_cfa_sf => |i| try writer.print(" {} {d:<1}", .{ abi.fmtRegister(i.operands.register, arch), i.operands.offset * cie.data_alignment_factor }),
+        .def_cfa_register => |i| try writer.print(" {}", .{ abi.fmtRegister(i.operands.register, arch) }),
+        .def_cfa_offset => |i| try writer.print(" {d:<1}", .{@intCast(i64, i.operands.offset)}),
+        .def_cfa_offset_sf => |i| try writer.print(" {d:<1}", .{i.operands.offset * cie.data_alignment_factor}),
+        .def_cfa_expression => |i| {
+            try writer.writeByte(' ');
+            try writeExpression(writer, i.operands.block, arch, addr_size_bytes, endian);
+        },
+        .expression => |i| {
+            try writer.print(" {} ", .{abi.fmtRegister(i.operands.register, arch)});
+            try writeExpression(writer, i.operands.block, arch, addr_size_bytes, endian);
+        },
+        .val_offset => {},
+        .val_offset_sf => {},
+        .val_expression => {},
+    }
+}
+
+fn writeFormat(writer: anytype, frame_type: FrameType, comptime is_cie: bool) !void {
+    try writer.print("  {s: <" ++ (if (is_cie) "23" else "14") ++ "}{s}\n", .{ "Format:", if (frame_type == .dwarf64) "DWARF64" else "DWARF32" });
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,6 +13,7 @@ pub fn main() !void {
     const params = comptime [_]clap.Param(clap.Help){
         clap.parseParam("--help                 Display this help and exit.") catch unreachable,
         clap.parseParam("--eh-frame             Display .eh_frame section contents.") catch unreachable,
+        clap.parseParam("--llvm-compatibility   Output is formatted exactly like llvm-dwarfdump, with no extra information.") catch unreachable,
         clap.parseParam("<FILE>") catch unreachable,
     };
 
@@ -42,7 +43,12 @@ pub fn main() !void {
     defer dd.deinit();
 
     if (res.args.@"eh-frame") {
-        try dd.printEhFrame(stdout);
+        try stdout.print("{s}:\tfile format {s}-{s}\n\n", .{ filename, switch (dd.ctx.tag) {
+            .elf => "elf64",
+            .macho => "MachO",
+        }, if (dd.ctx.getArch()) |arch| @tagName(arch) else "unknown" });
+
+        try dd.printEhFrames(stdout, res.args.@"llvm-compatibility");
     } else try dd.printCompileUnits(stdout);
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -43,10 +43,14 @@ pub fn main() !void {
     defer dd.deinit();
 
     if (res.args.@"eh-frame" != 0) {
-        try stdout.print("{s}:\tfile format {s}-{s}\n\n", .{ filename, switch (dd.ctx.tag) {
-            .elf => "elf64",
-            .macho => "Mach-O 64-bit",
-        }, if (dd.ctx.getArch()) |arch| @tagName(arch) else "unknown" });
+        try stdout.print("{s}:\tfile format {s}{s}\n", .{ filename, switch (dd.ctx.tag) {
+            .elf => "elf64-",
+            .macho => "Mach-O ",
+        }, if (dd.ctx.getArch()) |arch| switch (arch) {
+            .x86_64 => "x86_64",
+            .aarch64 => "arm64",
+            else => @tagName(arch),
+        } else "unknown" });
 
         try dd.printEhFrames(stdout, res.args.@"llvm-compatibility" != 0);
     } else try dd.printCompileUnits(stdout);

--- a/src/main.zig
+++ b/src/main.zig
@@ -27,7 +27,7 @@ pub fn main() !void {
     });
     defer res.deinit();
 
-    if (res.args.help) {
+    if (res.args.help != 0) {
         return printUsageWithHelp(stderr, params[0..]);
     }
 
@@ -42,13 +42,13 @@ pub fn main() !void {
     var dd = try DwarfDump.parse(gpa.allocator(), file);
     defer dd.deinit();
 
-    if (res.args.@"eh-frame") {
+    if (res.args.@"eh-frame" != 0) {
         try stdout.print("{s}:\tfile format {s}-{s}\n\n", .{ filename, switch (dd.ctx.tag) {
             .elf => "elf64",
-            .macho => "MachO",
+            .macho => "Mach-O 64-bit",
         }, if (dd.ctx.getArch()) |arch| @tagName(arch) else "unknown" });
 
-        try dd.printEhFrames(stdout, res.args.@"llvm-compatibility");
+        try dd.printEhFrames(stdout, res.args.@"llvm-compatibility" != 0);
     } else try dd.printCompileUnits(stdout);
 }
 


### PR DESCRIPTION
Note: This depends on the changes here (which are still pending): https://github.com/kcbanner/zig/tree/dwarf_unwind

I used this branch to develop the changes in the branch above, by comparing the output of `llvm-dwarfdump` on Ubuntu's libc via diff. This was a useful test case driver to verify the call frame and dwarf expression parsers I'm working on.

```
$ llvm-dwarfdump /lib/x86_64-linux-gnu/libc.so.6 --eh-frame > reference.txt
$ wc -l reference.txt
100436 reference.txt
$ zig-out/bin/zig-dwarfdump /lib/x86_64-linux-gnu/libc.so.6 --eh-frame --llvm-compatibility > output.txt
$ diff reference.txt output.txt
1c1
< /lib/x86_64-linux-gnu/libc.so.6:      file format elf64-x86-64
---
> /lib/x86_64-linux-gnu/libc.so.6:      file format elf64-x86_64
```

- Rework `printEhFrame` to use the std.dwarf call frame information parsers
- Change the output format to match that of `llvm-dwarfdump`
- Add `--llvm-compatibility`, which disables some extra output